### PR TITLE
chore: update `actions/setup-node` to v4

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,7 @@ outputs:
 runs:
   using: 'composite'
   steps:
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4
     - run: npm i -g neonctl@v1
       shell: bash
     - name: Reset branch


### PR DESCRIPTION
This solves deprecation warnings with node < 20 versions in GH actions