### PR TITLE
Fix bug with a connection string from the default branch

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -79,10 +79,11 @@ runs:
         echo "branch reset out:"
         cat branch_out
 
-        echo "branch_id=$(cat branch_out | jq --raw-output '.id')" >> $GITHUB_OUTPUT
+        branch_id=$(cat branch_out | jq --raw-output '.id')
+        echo "branch_id=${branch_id}" >> $GITHUB_OUTPUT
         
         cs_json () {
-          neonctl cs ${{inputs.branch_id}} \
+          neonctl cs ${branch_id} \
           --project-id ${{ inputs.project_id }} \
           $(if [[ -n "${{ inputs.cs_role_name }}" ]] && [[ "${{ inputs.cs_role_name }}" != "false" ]]; then echo "--role-name ${{ inputs.cs_role_name }}"; fi) \
           $(if [[ -n "${{ inputs.cs_database }}" ]] && [[ "${{ inputs.cs_database }}" != "false" ]]; then echo "--database-name ${{ inputs.cs_database }}"; fi) \
@@ -95,7 +96,7 @@ runs:
         CS_JSON=$(cs_json)
         CS_JSON_POOLED=$(cs_json true)
         DB_URL=$(echo $CS_JSON | jq -r '.connection_string')
-        DB_URL_WITH_POOLER=$(echo $CS_JSON | jq -r '.connection_string')
+        DB_URL_WITH_POOLER=$(echo $CS_JSON_POOLED | jq -r '.connection_string')
         
         echo "db_url=${DB_URL}" >> $GITHUB_OUTPUT
         echo "db_url_with_pooler=${DB_URL_WITH_POOLER}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
The old code uses inputs.branch_id which is empty and always returns connection string from the default branch.
+ bugfix for a connection url for a pooled connection