### PR TITLE
Proposed solution for db_url output issues

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -38,9 +38,6 @@ inputs:
     default: 'require'
 
 outputs:
-  branch_id:
-    description: 'Returns the branch id'
-    value: ${{ steps.reset-branch.outputs.branch_id }}
   db_url:
     description: 'DATABASE_URL of the branch after the reset'
     value: ${{ steps.reset-branch.outputs.db_url }}
@@ -78,12 +75,9 @@ runs:
         
         echo "branch reset out:"
         cat branch_out
-
-        branch_id=$(cat branch_out | jq --raw-output '.id')
-        echo "branch_id=${branch_id}" >> $GITHUB_OUTPUT
         
         cs_json () {
-          neonctl cs ${branch_id} \
+          neonctl cs ${{ inputs.branch }} \
           --project-id ${{ inputs.project_id }} \
           $(if [[ -n "${{ inputs.cs_role_name }}" ]] && [[ "${{ inputs.cs_role_name }}" != "false" ]]; then echo "--role-name ${{ inputs.cs_role_name }}"; fi) \
           $(if [[ -n "${{ inputs.cs_database }}" ]] && [[ "${{ inputs.cs_database }}" != "false" ]]; then echo "--database-name ${{ inputs.cs_database }}"; fi) \


### PR DESCRIPTION
I believe that there is an issue getting the branch_id as the action is outputting the default connection string rather than the connection string for the branch that was just reset to its parent

See issue #13

Using the branch name from the input seems to suffice 

I'm unsure what other change(s) should go into this like a version bump