### PR TITLE
`neonctl` doesn't need to be installed globally

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -61,7 +61,7 @@ runs:
   using: 'composite'
   steps:
     - uses: actions/setup-node@v4
-    - run: npm i -g neonctl@v2
+    - run: npm i neonctl@v2
       shell: bash
     - name: Reset branch
       env:


### PR DESCRIPTION
Let's not install it globally as it might be used by other pipelines that might need specific versions.