### PR TITLE
fix: use inputs.branch for neonctl cs to avoid empty branch_id

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -83,7 +83,7 @@ runs:
         echo "branch_id=${branch_id}" >> $GITHUB_OUTPUT
         
         cs_json () {
-          neonctl cs ${branch_id} \
+          neonctl cs ${{ inputs.branch }} \
           --project-id ${{ inputs.project_id }} \
           $(if [[ -n "${{ inputs.cs_role_name }}" ]] && [[ "${{ inputs.cs_role_name }}" != "false" ]]; then echo "--role-name ${{ inputs.cs_role_name }}"; fi) \
           $(if [[ -n "${{ inputs.cs_database }}" ]] && [[ "${{ inputs.cs_database }}" != "false" ]]; then echo "--database-name ${{ inputs.cs_database }}"; fi) \


### PR DESCRIPTION
## Problem

  When `neonctl branches reset` output is piped through `jq`, the resulting `branch_id` shell variable can be empty if `jq` produces unexpected output.

With an empty argument, `neonctl cs` falls back to the project default branch (the parent), causing the action to return the parent's connection string instead of the reset branch's.

  This is the root cause reported in #13 and #16.

  ## Fix

  Replace `${branch_id}` with `${{ inputs.branch }}` in the `neonctl cs` call.
  The `inputs.branch` value is always present, and `neonctl` accepts both branch names and IDs.

  The `branch_id` output is preserved — the jq parsing is kept, only its use as a `neonctl cs` argument is removed.

  ## Relation to PR #14

  PR #14 identified the same root cause but removed the `branch_id` output entirely, which is a breaking change for users referencing `${{ steps.reset-branch.outputs.branch_id }}` in downstream steps.

This PR applies the minimal correct fix.

  Closes #13
  Closes #16