### PR TITLE
Supply-chain followups: SHA pinning guidance, release workflow, lint

### DIFF
--- a/.github/scripts/lint_actions.py
+++ b/.github/scripts/lint_actions.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Lint composite action and workflow files for two supply-chain pitfalls.
+
+1. Every `uses:` ref must be pinned to a 40-char commit SHA. Tag-only refs
+   like `@v4` or `@main` are mutable and can be retargeted upstream.
+2. No `${{ inputs.* }}`, `${{ github.event.* }}`, or `${{ github.head_ref }}`
+   may appear inside a `run:` body. Those values can contain shell
+   metacharacters; route them through env: and reference as quoted bash vars.
+
+Run from the repo root: `python3 .github/scripts/lint_actions.py`.
+Exits non-zero if any issue is found, and emits GitHub `::error` annotations
+so they show up inline on PRs.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+USES_RE = re.compile(r"^\s*-?\s*uses:\s*([^\s#]+)")
+SHA_RE = re.compile(r"@[a-f0-9]{40}(/|$)")
+RUN_BLOCK_RE = re.compile(r"^(\s*)run:\s*[|>][-+]?\s*(?:#.*)?$")
+RUN_INLINE_RE = re.compile(r"^(\s*)run:\s*(.+)$")
+FORBIDDEN_IN_RUN = re.compile(
+    r"\$\{\{\s*("
+    r"inputs\.[a-zA-Z0-9_]+"
+    r"|github\.event\.[a-zA-Z0-9_.]+"
+    r"|github\.head_ref"
+    r")\s*\}\}"
+)
+
+
+def files_to_check() -> list[Path]:
+    targets: list[Path] = []
+    action_yml = ROOT / "action.yml"
+    if action_yml.exists():
+        targets.append(action_yml)
+    workflows = ROOT / ".github" / "workflows"
+    if workflows.is_dir():
+        targets.extend(sorted(p for p in workflows.iterdir() if p.suffix in {".yml", ".yaml"}))
+    actions = ROOT / ".github" / "actions"
+    if actions.is_dir():
+        targets.extend(sorted(actions.rglob("action.yml")))
+        targets.extend(sorted(actions.rglob("action.yaml")))
+    return targets
+
+
+def lint_file(path: Path) -> list[tuple[int, str]]:
+    issues: list[tuple[int, str]] = []
+    lines = path.read_text().splitlines()
+
+    in_run_block = False
+    run_key_indent = -1
+
+    for i, line in enumerate(lines, start=1):
+        indent = len(line) - len(line.lstrip(" "))
+
+        if in_run_block:
+            if line.strip() == "":
+                continue
+            if indent <= run_key_indent:
+                in_run_block = False
+            else:
+                if FORBIDDEN_IN_RUN.search(line):
+                    issues.append(
+                        (
+                            i,
+                            "untrusted context expression in `run:` body — "
+                            "route through env: and use as a quoted bash variable",
+                        )
+                    )
+                continue
+
+        m_uses = USES_RE.match(line)
+        if m_uses:
+            ref = m_uses.group(1)
+            if not (ref.startswith("./") or ref.startswith("docker://")):
+                if not SHA_RE.search(ref):
+                    issues.append(
+                        (
+                            i,
+                            f"action ref `{ref}` is not pinned to a 40-char commit SHA",
+                        )
+                    )
+            continue
+
+        m_block = RUN_BLOCK_RE.match(line)
+        if m_block:
+            in_run_block = True
+            run_key_indent = len(m_block.group(1))
+            continue
+
+        m_inline = RUN_INLINE_RE.match(line)
+        if m_inline and FORBIDDEN_IN_RUN.search(m_inline.group(2)):
+            issues.append(
+                (
+                    i,
+                    "untrusted context expression in single-line `run:` — "
+                    "route through env: and use as a quoted bash variable",
+                )
+            )
+
+    return issues
+
+
+def main() -> int:
+    failed = False
+    for path in files_to_check():
+        rel = path.relative_to(ROOT)
+        for lineno, msg in lint_file(path):
+            print(f"::error file={rel},line={lineno}::{msg}")
+            failed = True
+    if not failed:
+        print("lint_actions.py: all action refs SHA-pinned and no untrusted context in run: bodies")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/lint-actions.yml
+++ b/.github/workflows/lint-actions.yml
@@ -1,0 +1,24 @@
+name: Lint actions
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions: {}
+
+jobs:
+  lint:
+    name: SHA pinning + run-body injection checks
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Lint
+        run: python3 .github/scripts/lint_actions.py

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,51 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions: {}
+
+jobs:
+  release:
+    name: Publish GitHub Release with provenance
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
+    steps:
+      - name: Checkout tagged ref
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Build release tarball
+        id: archive
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          archive="reset-branch-action-${TAG}.tar.gz"
+          git archive --format=tar.gz --prefix="reset-branch-action-${TAG}/" -o "${archive}" "${TAG}"
+          sha256sum "${archive}" > "${archive}.sha256"
+          echo "archive=${archive}" >> "$GITHUB_OUTPUT"
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
+        with:
+          subject-path: ${{ steps.archive.outputs.archive }}
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+          ARCHIVE: ${{ steps.archive.outputs.archive }}
+        run: |
+          set -euo pipefail
+          gh release create "${TAG}" \
+            "${ARCHIVE}" \
+            "${ARCHIVE}.sha256" \
+            --generate-notes \
+            --verify-tag

--- a/README.md
+++ b/README.md
@@ -24,6 +24,20 @@ Using the action requires adding a Neon API key to your GitHub Secrets. There ar
   4. Name the secret `NEON_API_KEY` and paste your API key in the **Value** field.
   5. Click **Add secret**.
 
+## Pinning and security
+
+Always pin this action by its **commit SHA**, not by tag (`@v1`, `@v1.3.2`). Tags are mutable references — anyone with write access to this repository can move `@v1` to a different commit, so a pin-by-tag is effectively a trust-on-first-use against every future state of the repo. A SHA pin is immutable.
+
+Recommended pattern:
+
+```yml
+- uses: neondatabase/reset-branch-action@<commit-sha> # v1.3.3
+```
+
+Copy the SHA for the latest release from the [Releases page](https://github.com/neondatabase/reset-branch-action/releases). Dependabot can auto-bump the pin if you keep the `# vX.Y.Z` comment in the same format.
+
+Releases on this repository are published with a [build-provenance attestation](https://docs.github.com/en/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds), which you can verify against the GitHub OIDC issuer with `gh attestation verify`.
+
 ## Usage
 
 The following fields are required to run the Reset Branch action:
@@ -36,7 +50,7 @@ Setup the action in your workflow:
 
 ```yml
 steps:
-  - uses: neondatabase/reset-branch-action@v1
+  - uses: neondatabase/reset-branch-action@<commit-sha> # v1.3.3 — see https://github.com/neondatabase/reset-branch-action/releases
     id: reset-branch # Step ID to reference outputs
     with:
       project_id: your_neon_project_id
@@ -75,7 +89,7 @@ jobs:
   Reset-Neon-Branch:
     runs-on: ubuntu-24.04
     steps:
-      - uses: neondatabase/reset-branch-action@v1
+      - uses: neondatabase/reset-branch-action@<commit-sha> # v1.3.3 — see https://github.com/neondatabase/reset-branch-action/releases
         id: reset-branch
         with:
           project_id: ${{ vars.NEON_PROJECT_ID }}

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,27 @@
+# Security policy
+
+## Reporting a vulnerability
+
+Please report suspected security vulnerabilities in this action **privately**, not via a public GitHub issue.
+
+- Email: `security@neon.tech`
+- GitHub: use [private vulnerability reporting](https://github.com/neondatabase/reset-branch-action/security/advisories/new)
+
+We aim to acknowledge reports within 2 business days.
+
+## Scope
+
+This repository ships a composite GitHub Action that runs in the consumer's CI with the consumer's `NEON_API_KEY`. Security-relevant categories include:
+
+- Shell injection or command injection through any action input.
+- Privilege escalation against the consumer's CI runner or secrets.
+- Supply-chain issues with the action's runtime dependencies (`neonctl` and its transitive npm dependencies).
+- Mutation of release tags (`v1`, `v1.x`, `vX.Y.Z`) to point at unintended commits.
+
+## Pinning
+
+Consumers should pin this action by commit SHA, not by tag. See the "Pinning and security" section of the [README](./README.md) for the recommended pattern.
+
+## Disclosure
+
+We coordinate with the reporter on a disclosure timeline. Default is 90 days from acknowledgement, or sooner once a fix is shipped and consumers have had time to upgrade.


### PR DESCRIPTION
- README: switch consumer examples from @v1 (mutable tag) to SHA pinning with a # vX.Y.Z comment; add a "Pinning and security" section that explains the threat model and points to the Releases page.
- SECURITY.md: disclosure contact and policy, pin-by-SHA reminder.
- .github/workflows/release.yml: on push of a v*.*.* tag, builds a deterministic `git archive` tarball, attests it with actions/attest-build-provenance (Sigstore), and creates a GitHub Release with auto-generated notes. Top-level permissions: {}; the job opts in to contents:write, id-token:write, attestations:write only. actions/checkout uses persist-credentials: false.
- .github/scripts/lint_actions.py + .github/workflows/lint-actions.yml: guardrail CI that fails on (a) any `uses:` ref not pinned to a 40-char commit SHA in action.yml or any workflow, and (b) ${{ inputs.* }}, ${{ github.event.* }}, or ${{ github.head_ref }} interpolated inside a `run:` body. Prevents regressing the two fixes from #21.

All third-party action references in the new workflows are pinned to 40-char SHAs verified via `git ls-remote`.
